### PR TITLE
Docker container improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,16 +49,17 @@ The payloads of both messages are in JSON format.
 
 ## Run in a Docker container
 
-#### 0. Generate and start the docker container
+#### 0. Set your MQTT configuration
+MQTT settings must be changed to match your setup in docker/docker-entrypoint.sh.  
+Optionnaly you can also change the web interface port by changing http_host_path.
+
+Example:
+```./presence -http_host_path=0.0.0.0:5555 -mqtt_client_id=happy_bubbles -mqtt_host=192.168.0.123:1883 -mqtt_password=1234 -mqtt_username=homeassistant```
+
+#### 1. Generate and start the docker container
 1. Start docker/build.sh
 2. Start docker/run.sh
 3. The interface is available at http://locahost:5555
-
-#### 1. Settings
-MQTT and web interface settings can be added/changed in docker/docker-entrypoint.sh
-
-Example:
-```./presence -http_host_path=0.0.0.0:5555 -mqtt_client_id=happy_buble -mqtt_host=localhost:1883 -mqtt_password=1234 -mqtt_username=homeassistant```
 
 #### TODO
 * Publish the HTTP and MQTT API for presence server

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,10 @@
-FROM debian:jessie
+FROM alpine:3.6
 
 MAINTAINER Rinie Romain <romain.rinie@googlemail.com>
 
-RUN apt-get update && apt-get install -y mosquitto mosquitto-clients wget unzip
+RUN apk update \
+ && apk add ca-certificates wget unzip \
+ && update-ca-certificates
 
 RUN wget https://github.com/happy-bubbles/presence/releases/download/1.8.0/presence_linux_386.zip
 

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
-./presence -http_host_path=0.0.0.0:5555
+./presence -http_host_path=0.0.0.0:5555 -mqtt_client_id=happy_bubbles -mqtt_host=192.168.0.XXX:1883 -mqtt_password=1234 -mqtt_username=homeassistant


### PR DESCRIPTION
As discussed in [PR#10](https://github.com/happy-bubbles/presence/pull/10) the image is now based on Alpine Linux (21MB versus 190MB :+1: )

The MQTT server is not installed in the container anymore and an external MQTT server is required (typically the home-assistant integrated broker, but could be any). Configuration takes place in docker/docker-entrypoint.sh